### PR TITLE
feat: "추가 pet_board api 삭제 기능"

### DIFF
--- a/src/main/java/com/techeer/abandoneddog/global/entity/BaseEntity.java
+++ b/src/main/java/com/techeer/abandoneddog/global/entity/BaseEntity.java
@@ -21,4 +21,7 @@ public abstract class BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "deleted", nullable = false, columnDefinition = "bit(1) default 0")
+    private Boolean isDeleted = false;
 }

--- a/src/main/java/com/techeer/abandoneddog/pet_board/controller/PetBoardController.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/controller/PetBoardController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -76,4 +77,15 @@ public class PetBoardController {
         }
     }
 
+    @DeleteMapping("/{petBoardId}")
+    public ResponseEntity<?> deletePetBoard(@PathVariable Long petBoardId) {
+        try {
+            petBoardService.deletePetBoard(petBoardId);
+            return ResponseEntity.ok().body("게시물 삭제에 성공하였습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("게시물 삭제에 실패하였습니다.");
+        }
+    }
 }

--- a/src/main/java/com/techeer/abandoneddog/pet_board/controller/PetBoardController.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/controller/PetBoardController.java
@@ -3,7 +3,6 @@ package com.techeer.abandoneddog.pet_board.controller;
 import com.techeer.abandoneddog.pet_board.dto.PetBoardRequestDto;
 import com.techeer.abandoneddog.pet_board.dto.PetBoardResponseDto;
 import com.techeer.abandoneddog.pet_board.service.PetBoardService;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/techeer/abandoneddog/pet_board/entity/PetBoard.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/entity/PetBoard.java
@@ -14,14 +14,19 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE pet_board SET deleted = true WHERE pet_board_id = ?")
+@Where(clause = "deleted = false")
 @Table(name = "pet_board")
 public class PetBoard extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pet_board_id", updatable = false)
     private Long petBoardId;
 
 //    @Column(name = "pet_id", nullable = false)

--- a/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
@@ -41,4 +41,11 @@ public class PetBoardService {
         Page<PetBoard> petBoardPage = petBoardRepository.findAll(pageable);
         return petBoardPage.map(PetBoardResponseDto::fromEntity);
     }
+
+    @Transactional
+    public void deletePetBoard(Long petBoardId) {
+        PetBoard petBoard = petBoardRepository.findById(petBoardId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글을 찾을 수 없습니다. id=" + petBoardId));
+        petBoardRepository.delete(petBoard);
+    }
 }


### PR DESCRIPTION
## 개요
feat: "추가 pet_board api 삭제 기능"
각 entity에 sqldelete, where 어노테이션 추가
baseentity에 isDeleted 필드 추가

## PR 
어떤 변경 사항이 있나요?

- [✅ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [ ✅] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ✅] 변경 사항에 대한 테스트를 했습니다.
- [ ✅] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [ ✅] 기존의 코드에 영향이 없는 것을 확인했습니다.
