### PR TITLE
Feat#25 펫정보를 공공api와 개인으로 나누어서 저장

### DIFF
--- a/src/main/java/com/techeer/abandoneddog/AbandoneddogApplication.java
+++ b/src/main/java/com/techeer/abandoneddog/AbandoneddogApplication.java
@@ -2,8 +2,10 @@ package com.techeer.abandoneddog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class AbandoneddogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/techeer/abandoneddog/animal/Controller/AnimalInfoController.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/Controller/AnimalInfoController.java
@@ -1,5 +1,6 @@
 package com.techeer.abandoneddog.animal.Controller;
 
+import com.techeer.abandoneddog.animal.Dto.PetInfoCreateDto;
 import com.techeer.abandoneddog.animal.Dto.PetInfoRequestDto;
 import com.techeer.abandoneddog.animal.service.PetInfoService;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +21,14 @@ public class AnimalInfoController {
         this.petInfoService = petInfoService;
     }
 
-
+    @PostMapping("/pet_info/individual")
+    public ResponseEntity<?> createPetInfo(@RequestBody PetInfoCreateDto petInfoCreatedto) {
+        try {
+            return ResponseEntity.ok(petInfoService.createPetInfo(petInfoCreatedto));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("펫 정보 생성에 실패하였습니다.");
+        }
+    }
 
     @PostMapping("/pet_info")
     public ResponseEntity<?> posting(@RequestBody PetInfoRequestDto dto) {
@@ -40,6 +48,24 @@ public class AnimalInfoController {
 //        return ResponseEntity.ok( postservice.pageList(pageable));
 //
 //    }
+
+    @GetMapping("pet-info/public-pets")
+    public ResponseEntity<?> getPublicPets() {
+        try {
+            return ResponseEntity.ok(petInfoService.getPetInfoByPublicApiStatus(true));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Failed to retrieve public pet information.");
+        }
+    }
+
+    @GetMapping("pet-info/private-pets")
+    public ResponseEntity<?> getPrivatePets() {
+        try {
+            return ResponseEntity.ok(petInfoService.getPetInfoByPublicApiStatus(false));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Failed to retrieve private pet information.");
+        }
+    }
 
     @GetMapping("/pet_info/{id}")
     public ResponseEntity<?> getPost(@PathVariable Long id) {

--- a/src/main/java/com/techeer/abandoneddog/animal/Dto/PetInfoCreateDto.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/Dto/PetInfoCreateDto.java
@@ -1,0 +1,30 @@
+package com.techeer.abandoneddog.animal.Dto;
+
+import com.techeer.abandoneddog.animal.entity.Gender;
+import com.techeer.abandoneddog.animal.entity.Neuter;
+import com.techeer.abandoneddog.animal.entity.State;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class PetInfoCreateDto {
+    private String title;
+    private String petName;
+    private Gender gender;
+    private int age;
+    private Float weight;
+    private String breed;
+    private Neuter neuter;
+    private String address;
+    private String content;
+    private String thumbnailImage;
+    private String profileImage;
+    private State processState;
+    private LocalDate noticeSdt;
+    private LocalDate noticeEdt;
+    @Builder.Default
+    private boolean isPublicApi = false;
+}

--- a/src/main/java/com/techeer/abandoneddog/animal/Dto/PetInfoRequestDto.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/Dto/PetInfoRequestDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class PetInfoRequestDto {
 
-    private int shelterId;
+//    private int shelterId;
     private String petName;
     private PetType petType;
     private String breed;

--- a/src/main/java/com/techeer/abandoneddog/animal/Dto/PetInfoResponseDto.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/Dto/PetInfoResponseDto.java
@@ -11,7 +11,7 @@ import org.antlr.v4.runtime.misc.NotNull;
 @Builder
 public class PetInfoResponseDto {
 
-    private int shelterId;
+//    private int shelterId;
     private String petName;
     private PetType petType;
     private String breed;

--- a/src/main/java/com/techeer/abandoneddog/animal/entity/Neuter.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/entity/Neuter.java
@@ -1,5 +1,5 @@
 package com.techeer.abandoneddog.animal.entity;
 
-public enum Gender {
-    Male, Female, Unknown
+public enum Neuter {
+    YES, NO, UNKNOWN
 }

--- a/src/main/java/com/techeer/abandoneddog/animal/entity/PetInfo.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/entity/PetInfo.java
@@ -2,7 +2,9 @@ package com.techeer.abandoneddog.animal.entity;
 
 
 import com.techeer.abandoneddog.animal.Dto.PetInfoRequestDto;
+import com.techeer.abandoneddog.shelter.entity.Shelter;
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,26 +20,73 @@ public class PetInfo {
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
-    @Column(nullable = false)
-    private int shelterId;
+    @ManyToOne
+    @JoinColumn(name = "shelter_id", nullable = true)
+    private Shelter shelter;
 
-    @Column(nullable = false)
+    @Column(name = "pet_name")
     private String petName;
 
+    private String desertionNo;
+
+    private String thumbnailImage; // 사진 축소판
+
     @Column
+    @Enumerated(EnumType.STRING)
     private PetType petType;
 
-    private String breed;
+    private String breed; //품종
 
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     private Float weight;
 
+    private LocalDate happenDt; //접수일
+
+    private String happenPlace; //발견장소
+
+    private String color; //색상
+
+    private int age;
+
+    private String noticeNo; //공고번호
+
+    private LocalDate noticeSdt; //공고시작일
+
+    private LocalDate noticeEdt; //공고종료일
+
+    private String profileImage; //이미지
+
+    @Enumerated(EnumType.STRING)
+    private State processState; //상태
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "neuter", length = 10)
+    private Neuter neuter; //중성화여부 Y : 예, N : 아니오, U : 미상
+
+    private String specialMark; //특징
+
+    private String title;
+
+    private String address;
+
+    private String content;
+
+    private boolean isPublicApi; // 공공API 사용 여부
+
+    private String orgNm;        // 관할기관
+
+    private String chargeNm;     // 담당자
+
+    private String officetel;    // 담당자연락처
+
+
 
     public void update(PetInfoRequestDto dto) {
 
-         shelterId=dto.getShelterId();
-         petName=dto.getPetName();
+//         shelterId=dto.getShelterId();
+//         petName=dto.getPetName();
          petType=dto.getPetType();
          breed=dto.getBreed();
         gender=dto.getGender();

--- a/src/main/java/com/techeer/abandoneddog/animal/entity/PetType.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/entity/PetType.java
@@ -1,6 +1,5 @@
 package com.techeer.abandoneddog.animal.entity;
 
 public enum PetType {
-    CAT,
-    DOG
+    고양이, 개, 기타축종
 }

--- a/src/main/java/com/techeer/abandoneddog/animal/entity/State.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/entity/State.java
@@ -1,0 +1,31 @@
+package com.techeer.abandoneddog.animal.entity;
+
+public enum State {
+    공고중("공고중"),
+    보호중("보호중"),
+    종료_자연사("종료(자연사)"),
+    종료_안락사("종료(안락사)"),
+    종료_반환("종료(반환)"),
+    종료_입양("종료(입양)"),
+    종료_기증("종료(기증)"),
+    종료_방사("종료(방사)");
+
+    private final String description;
+
+    State(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static State fromDescription(String description) {
+        for (State state : values()) {
+            if (state.getDescription().equals(description)) {
+                return state;
+            }
+        }
+        throw new IllegalArgumentException("No constant with description " + description + " found");
+    }
+}

--- a/src/main/java/com/techeer/abandoneddog/animal/repository/PetInfoRepository.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/repository/PetInfoRepository.java
@@ -1,11 +1,12 @@
 package com.techeer.abandoneddog.animal.repository;
 
 import com.techeer.abandoneddog.animal.entity.PetInfo;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public interface PetInfoRepository extends JpaRepository<PetInfo,Long> {
-
+    List<PetInfo> findByIsPublicApi(boolean isPublicApi);
 }

--- a/src/main/java/com/techeer/abandoneddog/animal/service/PetInfoService.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/service/PetInfoService.java
@@ -1,9 +1,11 @@
 package com.techeer.abandoneddog.animal.service;
 
+import com.techeer.abandoneddog.animal.Dto.PetInfoCreateDto;
 import com.techeer.abandoneddog.animal.Dto.PetInfoRequestDto;
 import com.techeer.abandoneddog.animal.entity.PetInfo;
 import com.techeer.abandoneddog.animal.repository.PetInfoRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,8 +24,8 @@ public class PetInfoService {
 
     public PetInfo createPetInfo(PetInfoRequestDto dto) {
         return petInfoRepository.save(PetInfo.builder()
-                .shelterId(dto.getShelterId())
-                .petName(dto.getPetName())
+//                .shelterId(dto.getShelterId())
+//                .petName(dto.getPetName())
                 .petType(dto.getPetType())
                 .breed(dto.getBreed())
                 .gender(dto.getGender())
@@ -32,11 +34,37 @@ public class PetInfoService {
                 .build());
     }
 
+    @Transactional
+    public PetInfo createPetInfo(PetInfoCreateDto dto) {
+        PetInfo petInfo = PetInfo.builder()
+                .title(dto.getTitle())
+                .petName(dto.getPetName())
+                .gender(dto.getGender())
+                .age(dto.getAge())
+                .weight(dto.getWeight())
+                .breed(dto.getBreed())
+                .neuter(dto.getNeuter())
+                .address(dto.getAddress())
+                .content(dto.getContent())
+                .thumbnailImage(dto.getThumbnailImage())
+                .profileImage(dto.getProfileImage())
+                .processState(dto.getProcessState())
+                .noticeSdt(dto.getNoticeSdt())
+                .noticeEdt(dto.getNoticeEdt())
+                .isPublicApi(dto.isPublicApi())
+                .build();
+        return petInfoRepository.save(petInfo);
+    }
+
 
 //        public List<PostResponseDto> pageList(Pageable pageable) {
 //            Page<Post> postList = postRepository.findAll(pageable);
 //            return postMapper.toDtoPageList(postList).getContent();
 //        }
+
+    public List<PetInfo> getPetInfoByPublicApiStatus(boolean isPublicApi) {
+        return petInfoRepository.findByIsPublicApi(isPublicApi);
+    }
 
     public PetInfo getPetInfo(Long id) {
         return petInfoRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("not found"));

--- a/src/main/java/com/techeer/abandoneddog/global/config/JpaConfig.java
+++ b/src/main/java/com/techeer/abandoneddog/global/config/JpaConfig.java
@@ -1,9 +1,15 @@
 package com.techeer.abandoneddog.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/techeer/abandoneddog/openapi/controller/AnimalController.java
+++ b/src/main/java/com/techeer/abandoneddog/openapi/controller/AnimalController.java
@@ -1,0 +1,34 @@
+// AnimalController.java
+
+package com.techeer.abandoneddog.openapi.controller;
+
+import com.techeer.abandoneddog.animal.entity.PetInfo;
+import com.techeer.abandoneddog.openapi.service.AnimalService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class AnimalController {
+
+    private final AnimalService animalService;
+
+    @Autowired
+    public AnimalController(AnimalService animalService) {
+        this.animalService = animalService;
+    }
+
+    @GetMapping("/api/v1/animals")
+    public ResponseEntity<List<PetInfo>> getAnimals(
+            @RequestParam(defaultValue = "1") String pageNo,
+            @RequestParam(defaultValue = "1000") String numOfRows) {
+
+        animalService.fetchAllAnimals();
+        List<PetInfo> allAnimals = animalService.fetchAnimals(pageNo, numOfRows);
+        return allAnimals.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(allAnimals);
+    }
+}

--- a/src/main/java/com/techeer/abandoneddog/openapi/service/AnimalService.java
+++ b/src/main/java/com/techeer/abandoneddog/openapi/service/AnimalService.java
@@ -1,0 +1,133 @@
+package com.techeer.abandoneddog.openapi.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.abandoneddog.animal.entity.*;
+import com.techeer.abandoneddog.animal.repository.PetInfoRepository;
+import com.techeer.abandoneddog.shelter.entity.Shelter;
+import com.techeer.abandoneddog.shelter.service.ShelterService;
+import com.techeer.abandoneddog.openapi.util.AnimalDataExtractor;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class AnimalService {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+    private final ShelterService shelterService;
+    private final PetInfoRepository petInfoRepository;
+    private final RestTemplate restTemplate;
+    private final String decodeServiceKey;
+
+    public AnimalService(EntityManager entityManager,
+                         ShelterService shelterService,
+                         PetInfoRepository petInfoRepository,
+                         RestTemplate restTemplate,
+                         @Value("${api.serviceKey}") String decodeServiceKey) {
+        this.entityManager = entityManager;
+        this.shelterService = shelterService;
+        this.petInfoRepository = petInfoRepository;
+        this.restTemplate = restTemplate;
+        this.decodeServiceKey = decodeServiceKey;
+    }
+
+    @Transactional
+    public List<PetInfo> fetchAnimals(String pageNo, String numOfRows) {
+        String encodedServiceKey;
+        try {
+            encodedServiceKey = URLEncoder.encode(decodeServiceKey, "UTF-8");
+        } catch (Exception e) {
+            System.out.println("Encoding failed: " + e.getMessage());
+            return new ArrayList<>();
+        }
+
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl("http://apis.data.go.kr/1543061/abandonmentPublicSrvc/abandonmentPublic")
+                .queryParam("serviceKey", encodedServiceKey)
+                .queryParam("numOfRows", numOfRows)
+                .queryParam("pageNo", pageNo)
+                .queryParam("_type", "json")
+                .build(true)
+                .toUri();
+
+        String jsonResponse = restTemplate.getForObject(uri, String.class);
+        System.out.println(uri);
+
+        AnimalDataExtractor.processAndDeleteResponseFile(jsonResponse);
+        return parseAndSaveAnimals(jsonResponse);
+    }
+
+    @Transactional
+    public List<PetInfo> parseAndSaveAnimals(String json) {
+        List<PetInfo> pets = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode root = mapper.readTree(json);
+            JsonNode items = root.path("response").path("body").path("items").path("item");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+            if (items.isArray()) {
+                for (JsonNode item : items) {
+                    Shelter shelter = shelterService.saveShelter(
+                            item.path("careNm").asText(),
+                            item.path("careTel").asText(),
+                            item.path("careAddr").asText()
+                    );
+                    PetInfo pet = AnimalDataExtractor.buildPetInfoFromJson(item, formatter, shelter);
+                    pets.add(pet);
+                }
+            }
+
+            persistPets(pets);
+
+        } catch (Exception e) {
+            System.err.println("Error parsing or saving animals: " + e.getMessage());
+        }
+        return pets;
+    }
+
+    @Transactional
+    public void persistPets(List<PetInfo> pets) {
+        int batchSize = 725;
+        for (int i = 0; i < pets.size(); i++) {
+            entityManager.persist(pets.get(i));
+            if (i % batchSize == 0 && i > 0) {
+                entityManager.flush();
+                entityManager.clear();
+            }
+        }
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+
+    @Transactional
+    public void fetchAllAnimals() {
+        final int numOfRows = 1000;
+        int pageNo = 1;
+        List<PetInfo> pets;
+        long fetchStartTime, fetchEndTime;
+
+        do {
+            fetchStartTime = System.currentTimeMillis();
+            pets = fetchAnimals(String.valueOf(pageNo), String.valueOf(numOfRows));
+            petInfoRepository.saveAll(pets);
+            fetchEndTime = System.currentTimeMillis();
+
+            System.out.println("Time taken to fetch and save page " + pageNo + ": " + (fetchEndTime - fetchStartTime) + " milliseconds");
+            pageNo++;
+        } while (!pets.isEmpty());
+    }
+}

--- a/src/main/java/com/techeer/abandoneddog/openapi/util/AnimalDataExtractor.java
+++ b/src/main/java/com/techeer/abandoneddog/openapi/util/AnimalDataExtractor.java
@@ -1,0 +1,106 @@
+package com.techeer.abandoneddog.openapi.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.techeer.abandoneddog.animal.entity.*;
+import com.techeer.abandoneddog.shelter.entity.Shelter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AnimalDataExtractor {
+
+    public static void processAndDeleteResponseFile(String response) {
+        try {
+            Path path = Path.of("animals_response.json");
+            if (Files.exists(path)) {
+                Files.delete(path);
+                System.out.println("Response file deleted successfully.");
+            }
+            Files.writeString(path, response, StandardOpenOption.CREATE);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("Failed to delete or write response file.");
+        }
+    }
+
+    public static PetInfo buildPetInfoFromJson(JsonNode item, DateTimeFormatter formatter, Shelter shelter) {
+        String kindCode = item.path("kindCd").asText();
+        String extractedPetType = extractPetType(kindCode);
+        String breed = kindCode.replaceAll("\\[.*?\\] ", "");
+
+        return PetInfo.builder()
+                .shelter(shelter)
+                .desertionNo(item.path("desertionNo").asText())
+                .thumbnailImage(item.path("filename").asText())
+                .happenDt(LocalDate.parse(item.path("happenDt").asText(), formatter))
+                .happenPlace(item.path("happenPlace").asText())
+                .breed(breed)
+                .petType(PetType.valueOf(extractedPetType.toUpperCase().replaceAll("\\s", "")))
+                .color(item.path("colorCd").asText())
+                .age(extractYearFromAge(item.path("age").asText()))
+                .weight(extractWeight(item.path("weight").asText()))
+                .noticeNo(item.path("noticeNo").asText())
+                .noticeSdt(LocalDate.parse(item.path("noticeSdt").asText(), formatter))
+                .noticeEdt(LocalDate.parse(item.path("noticeEdt").asText(), formatter))
+                .profileImage(item.path("popfile").asText())
+                .processState(State.fromDescription(item.path("processState").asText()))
+                .gender(Gender.valueOf(convertSexCdToGender(item.path("sexCd").asText())))
+                .neuter(Neuter.valueOf(convertNeuterYnToNeuter(item.path("neuterYn").asText())))
+                .specialMark(item.path("specialMark").asText())
+                .orgNm(item.path("orgNm").asText())
+                .chargeNm(item.path("chargeNm").asText())
+                .officetel(item.path("officetel").asText())
+                .isPublicApi(true)
+                .build();
+    }
+
+    private static String extractPetType(String kindCd) {
+        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
+        Matcher matcher = pattern.matcher(kindCd);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+        return null;
+    }
+
+    private static int extractYearFromAge(String age) {
+        return Integer.parseInt(age.substring(0, 4));
+    }
+
+    private static float extractWeight(String weight) {
+        try {
+            String cleanWeight = weight.replaceAll("[^\\d.]", "");
+            return Float.parseFloat(cleanWeight);
+        } catch (NumberFormatException e) {
+            System.err.println("Invalid weight format: " + weight);
+            return 0;
+        }
+    }
+    private static String convertSexCdToGender(String sexCd) {
+        switch (sexCd) {
+            case "M":
+                return "Male";
+            case "F":
+                return "Female";
+            default:
+                return "Unknown";
+        }
+    }
+
+    private static String convertNeuterYnToNeuter(String neuterYn) {
+        switch (neuterYn) {
+            case "Y":
+                return "YES";
+            case "N":
+                return "NO";
+            default:
+                return "UNKNOWN";
+        }
+    }
+}
+

--- a/src/main/java/com/techeer/abandoneddog/shelter/controller/ShelterController.java
+++ b/src/main/java/com/techeer/abandoneddog/shelter/controller/ShelterController.java
@@ -1,0 +1,25 @@
+package com.techeer.abandoneddog.shelter.controller;
+
+import com.techeer.abandoneddog.shelter.dto.ShelterResponseDto;
+import com.techeer.abandoneddog.shelter.entity.Shelter;
+import com.techeer.abandoneddog.shelter.service.ShelterService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/shelters")
+public class ShelterController {
+
+    @Autowired
+    private ShelterService shelterService;
+
+    @GetMapping
+    public ResponseEntity<List<ShelterResponseDto>> getAllShelters() {
+        List<ShelterResponseDto> shelters = shelterService.findAllShelters();
+        return ResponseEntity.ok(shelters);
+    }
+}

--- a/src/main/java/com/techeer/abandoneddog/shelter/dto/ShelterResponseDto.java
+++ b/src/main/java/com/techeer/abandoneddog/shelter/dto/ShelterResponseDto.java
@@ -1,0 +1,17 @@
+package com.techeer.abandoneddog.shelter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShelterResponseDto {
+    private Long id;
+    private String name;
+    private String phoneNumber;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/techeer/abandoneddog/shelter/entity/Shelter.java
+++ b/src/main/java/com/techeer/abandoneddog/shelter/entity/Shelter.java
@@ -1,0 +1,62 @@
+package com.techeer.abandoneddog.shelter.entity;
+
+import com.techeer.abandoneddog.animal.entity.PetInfo;
+import com.techeer.abandoneddog.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import lombok.*;
+
+import java.util.List;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE user SET deleted = true WHERE shelter_id = ?")
+@Where(clause = "deleted = false")
+@Table(name = "shelter")
+public class Shelter extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shelter_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;        // 보호소 이름
+
+    @Column(nullable = false, length = 14)
+    private String phoneNumber; // 보호소 전화번호
+
+    @Column(nullable = false, length = 200)
+    private String address;     // 보호소 주소
+
+    @Column(nullable = true)
+    private Double latitude;    // 위도
+
+    @Column(nullable = true)
+    private Double longitude;   // 경도
+
+    @OneToMany(mappedBy = "shelter")
+    private List<PetInfo> pets = new ArrayList<>(); // 이 보호소에 속한 펫 정보
+
+    public Shelter(Long id, String name, String phoneNumber, String address, List<PetInfo> pets, Double latitude, Double longitude) {
+        this.id = id;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.pets = pets;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public void setLatitude(double latitude) {
+        this.latitude = latitude;
+    }
+
+    public void setLongitude(double longitude) {
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/techeer/abandoneddog/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/techeer/abandoneddog/shelter/repository/ShelterRepository.java
@@ -1,0 +1,9 @@
+package com.techeer.abandoneddog.shelter.repository;
+
+import com.techeer.abandoneddog.shelter.entity.Shelter;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShelterRepository extends JpaRepository<Shelter, Long> {
+    Optional<Shelter> findByNameAndPhoneNumberAndAddress(String name, String phoneNumber, String address);
+}

--- a/src/main/java/com/techeer/abandoneddog/shelter/service/ShelterService.java
+++ b/src/main/java/com/techeer/abandoneddog/shelter/service/ShelterService.java
@@ -1,0 +1,35 @@
+package com.techeer.abandoneddog.shelter.service;
+
+import com.techeer.abandoneddog.shelter.dto.ShelterResponseDto;
+import com.techeer.abandoneddog.shelter.entity.Shelter;
+import com.techeer.abandoneddog.shelter.repository.ShelterRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ShelterService {
+
+    @Autowired
+    private ShelterRepository shelterRepository;
+
+    public Shelter saveShelter(String name, String phoneNumber, String address) {
+        Optional<Shelter> existingShelter = shelterRepository.findByNameAndPhoneNumberAndAddress(name, phoneNumber, address);
+        return existingShelter.orElseGet(() -> shelterRepository.save(new Shelter(null, name, phoneNumber, address, new ArrayList<>(), null, null)));
+    }
+
+    public List<ShelterResponseDto> findAllShelters() {
+        return shelterRepository.findAll().stream()
+                .map(shelter -> new ShelterResponseDto(
+                        shelter.getId(),
+                        shelter.getName(),
+                        shelter.getPhoneNumber(),
+                        shelter.getAddress(),
+                        shelter.getLatitude(),
+                        shelter.getLongitude()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Feat#25 펫정보를 공공api와 개인으로 나누어서 저장
개인이 펫정보 저장할때는 보호소 정보 없게 저장
isPublicApi로 개인, 공공 api 구분

## PR 
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
