### PR TITLE
fix: 펫 분양/입양 게시글 작성할때 개인정보 보호소에 저장되도록 수정

### DIFF
--- a/src/main/java/com/techeer/abandoneddog/animal/PetInfoDto/PetInfoDto.java
+++ b/src/main/java/com/techeer/abandoneddog/animal/PetInfoDto/PetInfoDto.java
@@ -14,8 +14,9 @@ public class PetInfoDto {
     private String sexCd;
     private String kindCd;
     private String petType;
+    private boolean isPublicApi;
 
-    public PetInfoDto(Long id, Long desertionNo, String filename, String popfile, String processState, String age, String weight, String sexCd, String kindCd, String petType) {
+    public PetInfoDto(Long id, Long desertionNo, String filename, String popfile, String processState, String age, String weight, String sexCd, String kindCd, String petType, boolean isPublicApi) {
         this.id = id;
         this.desertionNo = desertionNo;
         this.filename = filename;
@@ -26,5 +27,6 @@ public class PetInfoDto {
         this.sexCd = sexCd;
         this.kindCd = kindCd;
         this.petType = petType;
+        this.isPublicApi = isPublicApi;
     }
 }

--- a/src/main/java/com/techeer/abandoneddog/chatting/controller/WebSocketMessageController.java
+++ b/src/main/java/com/techeer/abandoneddog/chatting/controller/WebSocketMessageController.java
@@ -14,20 +14,18 @@ public class WebSocketMessageController {
 
     private final ChatService chatService;
 
-    @MessageMapping("/message")
-    public void handleMessage(SimplifiedMessageDto messageDto) {
-        switch (messageDto.getType()) {
-            case ENTER:
-                chatService.enterChatRoom(messageDto);
-                break;
-            case TALK:
-                chatService.sendMessageToChatRoom(messageDto);
-                break;
-            case LEAVE:
-                chatService.leaveChatRoom(messageDto.getSenderId(), messageDto.getChatRoomId());
-                break;
-            default:
-                log.warn("Unknown message type: {}", messageDto.getType());
-        }
+    @MessageMapping("/message/enter")
+    public void handleEnterMessage(SimplifiedMessageDto messageDto) {
+        chatService.enterChatRoom(messageDto);
+    }
+
+    @MessageMapping("/message/talk")
+    public void handleTalkMessage(SimplifiedMessageDto messageDto) {
+        chatService.sendMessageToChatRoom(messageDto);
+    }
+
+    @MessageMapping("/message/leave")
+    public void handleLeaveMessage(SimplifiedMessageDto messageDto) {
+        chatService.leaveChatRoom(messageDto.getSenderId(), messageDto.getChatRoomId());
     }
 }

--- a/src/main/java/com/techeer/abandoneddog/pet_board/dto/PetBoardResponseDto.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/dto/PetBoardResponseDto.java
@@ -35,7 +35,8 @@ public class PetBoardResponseDto {
                     petBoard.getPetInfo().getWeight(),
                     petBoard.getPetInfo().getSexCd(),
                     petBoard.getPetInfo().getKindCd(),
-                    petBoard.getPetInfo().getPetType()
+                    petBoard.getPetInfo().getPetType(),
+                    petBoard.getPetInfo().isPublicApi()
             );
         }
 

--- a/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
@@ -7,8 +7,11 @@ import com.techeer.abandoneddog.pet_board.dto.PetBoardResponseDto;
 import com.techeer.abandoneddog.pet_board.entity.PetBoard;
 import com.techeer.abandoneddog.pet_board.entity.Status;
 import com.techeer.abandoneddog.pet_board.repository.PetBoardRepository;
+import com.techeer.abandoneddog.shelter.entity.Shelter;
+import com.techeer.abandoneddog.shelter.repository.ShelterRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,6 +27,7 @@ import java.util.List;
 public class PetBoardService {
     private final PetBoardRepository petBoardRepository;
     private final PetInfoRepository petInfoRepository;
+    private final ShelterRepository shelterRepository;
 
     @Transactional
     public Long createPetBoard(PetBoardRequestDto petBoardRequestDto) {
@@ -31,6 +35,14 @@ public class PetBoardService {
             PetInfo petInfo = petBoardRequestDto.getPetInfo();
             petInfo.setPublicApi(false);
             petInfo.setPetBoardStored(false);
+
+            Shelter shelter = petInfo.getShelter();
+            if (shelter != null) {
+                shelter = shelterRepository.save(shelter);
+            }
+
+            petInfo.setShelter(shelter);
+
             PetInfo savedPetInfo = petInfoRepository.save(petInfo);
 
             Status status = Status.fromProcessState(savedPetInfo.getProcessState());

--- a/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
@@ -36,7 +36,7 @@ public class PetBoardService {
             Status status = Status.fromProcessState(savedPetInfo.getProcessState());
 
             PetBoard newPetBoard = PetBoard.builder()
-                    .title(String.valueOf(savedPetInfo.getDesertionNo()))
+                    .title(String.valueOf(petBoardRequestDto.getTitle()))
                     .description(savedPetInfo.getSpecialMark())
                     .petInfo(savedPetInfo)
                     .petType(savedPetInfo.getPetType())


### PR DESCRIPTION
## 개요
보호소 이름에 user_id , 보호소 전화번호에 user 전화번호 , 보호소 주소에 보호자가 원하는 주소 저장

## PR 
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
