### PR TITLE
fix: 개인이 작성한 글 desertionNo 대신에 title 반환하기

### DIFF
--- a/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
+++ b/src/main/java/com/techeer/abandoneddog/pet_board/service/PetBoardService.java
@@ -60,7 +60,7 @@ public class PetBoardService {
 
             PetBoard newPetBoard = PetBoard.builder()
 
-                    .title("["+savedPetInfo.getKindCd()+"]"+String.valueOf(savedPetInfo.getDesertionNo()))
+                    .title("["+savedPetInfo.getKindCd()+"]"+String.valueOf(petBoardRequestDto.getTitle()))
                     .description(savedPetInfo.getSpecialMark())
                     .petInfo(savedPetInfo)
                     .petType(savedPetInfo.getPetType())


### PR DESCRIPTION
개인이 작성한 글에는 유기번호가 없기 때문에 title 반환

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## PR 
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
